### PR TITLE
refactor: use public openclaw/plugin-sdk API instead of internal modules

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,36 @@
+# Dependencies
+node_modules/
+
+# Build outputs
+dist/
+build/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Testing
+coverage/
+.nyc_output/
+
+# Documentation (included in separate docs site)
+docs/
+docs-site/
+
+# Git
+.git/
+.gitignore
+
+# Temp files
+*.tmp
+*.log
+npm-debug.log*
+
+# Claude
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,390 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a **TypeScript plugin** for OpenClaw that integrates WeCom (企业微信/WeChat Work) as a communication channel. It enables AI agents to communicate via WeCom, handle rich media messages, and provide remote browser control from mobile devices.
+
+**Key Technologies:**
+- TypeScript (ES2022, NodeNext modules)
+- Node.js >= 18
+- Vitest for testing
+- OpenClaw plugin SDK (peer dependency >= 2026.1.26)
+
+## Installation
+
+This plugin has been refactored to use only the public `openclaw/plugin-sdk` API and can now be installed as a standalone npm package.
+
+### Installing the Plugin
+
+**From npm (recommended):**
+```bash
+openclaw plugins install wecom-openclaw-integration
+```
+
+**From local directory (development):**
+```bash
+# Copy plugin files
+openclaw plugins install /path/to/wecom-openclaw-plugin
+
+# Or link for active development (no copying)
+openclaw plugins install -l /path/to/wecom-openclaw-plugin
+```
+
+**From archive:**
+```bash
+openclaw plugins install ./wecom-openclaw-integration-1.0.0.tgz
+```
+
+### Managing the Plugin
+
+```bash
+# List all plugins
+openclaw plugins list
+
+# Enable the plugin
+openclaw plugins enable wecom
+
+# Disable the plugin
+openclaw plugins disable wecom
+
+# Update plugin (if installed from npm)
+openclaw plugins update wecom
+```
+
+**Important:** After installation or configuration changes, restart the OpenClaw Gateway for changes to take effect.
+
+## Refactoring History
+
+**Version 1.0.0+** - This plugin has been refactored to use only the public `openclaw/plugin-sdk` API, following the pattern established by the [Feishu plugin](https://github.com/m1heng/clawdbot-feishu).
+
+**Key changes:**
+- Replaced internal API imports with `PluginRuntime` methods
+- Uses `runtime.channel.reply.dispatchReplyFromConfig()` instead of internal dispatcher
+- Uses `runtime.channel.routing.resolveAgentRoute()` for routing
+- Uses `runtime.channel.reply.formatAgentEnvelope()` for message formatting
+- Uses `runtime.channel.text.*` utilities for text chunking and markdown handling
+- Created `reply-dispatcher.ts` following the Feishu plugin pattern
+
+**Benefits:**
+- ✅ Can be installed as a standalone npm package
+- ✅ No longer requires OpenClaw workspace installation
+- ✅ Uses stable public APIs instead of internal modules
+- ✅ Easier to maintain and update
+
+## Build and Development Commands
+
+### Building
+```bash
+# This plugin is built as part of the OpenClaw workspace
+# From the OpenClaw root directory:
+pnpm build
+
+# TypeScript compilation outputs to ./dist/
+# Entry point: index.ts
+```
+
+### Testing
+```bash
+# Run all tests
+pnpm test
+
+# Run tests with coverage
+pnpm test -- --coverage
+
+# Run specific test file
+pnpm test test/api.test.ts
+
+# Watch mode
+pnpm test -- --watch
+```
+
+### Running the Plugin
+```bash
+# Start OpenClaw gateway with this plugin enabled
+node dist/entry.js gateway
+
+# The plugin loads automatically if enabled in ~/.openclaw/openclaw.json
+```
+
+## Architecture
+
+### Plugin Structure
+
+This is an **OpenClaw ChannelPlugin** that implements bidirectional communication with WeCom:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    OpenClaw Runtime                      │
+│  ┌────────────────────────────────────────────────────┐ │
+│  │              WeCom Plugin (index.ts)               │ │
+│  │  - Registers channel                               │ │
+│  │  - Sets up HTTP webhook handler                    │ │
+│  │  - Initializes event system                        │ │
+│  └────────────────────────────────────────────────────┘ │
+│           │                                    │          │
+│           ▼                                    ▼          │
+│  ┌─────────────────┐              ┌──────────────────┐  │
+│  │  WeComChannel   │              │  HTTP Webhook    │  │
+│  │  (channel.ts)   │              │  (monitor.ts)    │  │
+│  │  - Send msgs    │              │  - Receive msgs  │  │
+│  │  - Media upload │              │  - Decrypt       │  │
+│  └─────────────────┘              │  - Verify sig    │  │
+│           │                        └──────────────────┘  │
+│           ▼                                    │          │
+│  ┌─────────────────────────────────────────────────────┐│
+│  │           WeComApiClient (api.ts)                   ││
+│  │  - Token management                                 ││
+│  │  - HTTP requests to WeCom API                       ││
+│  │  - Media upload/download                            ││
+│  └─────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+                  WeCom API Servers
+```
+
+### Core Modules
+
+**index.ts** (Plugin Entry Point)
+- Registers the plugin with OpenClaw
+- Sets up HTTP webhook handler at `/wecom/callback`
+- Initializes event system and mini program support
+- Validates WeCom credentials on startup
+
+**src/channel.ts** (242 lines)
+- Implements `ChannelPlugin` interface for OpenClaw
+- Handles outbound message sending
+- Manages channel capabilities and configuration
+
+**src/monitor.ts** (refactored)
+- HTTP webhook handler for WeCom callbacks
+- Message decryption (AES-256-CBC) and signature verification (SHA1)
+- Message deduplication
+- Uses public `PluginRuntime` API to dispatch messages to OpenClaw
+- Handles routing, envelope formatting, and history management
+
+**src/reply-dispatcher.ts** (new)
+- Creates reply dispatcher for sending responses back to WeCom
+- Handles text chunking, markdown table conversion
+- Manages media payload delivery (images, files, videos)
+- Integrates with OpenClaw's typing callbacks and human delay system
+- Follows the pattern from the Feishu plugin
+
+**src/api.ts** (857 lines)
+- WeCom API client with automatic token refresh
+- Methods for sending text, images, voice, video, files, cards
+- Media upload/download handling
+- Token caching and expiration management
+
+**src/crypto.ts** (134 lines)
+- AES-256-CBC encryption/decryption for message security
+- SHA1 signature verification for webhook authenticity
+- PKCS7 padding implementation
+
+**src/parser.ts** (165 lines)
+- XML message parsing using fast-xml-parser
+- Extracts message content, user info, and metadata
+- Handles various message types (text, image, voice, video, file, location, link, event)
+
+**src/events.ts** (284 lines)
+- Event handling system for WeCom events (subscribe, click, scan, location)
+- Custom event handler registration
+- Welcome message support for new users
+
+**src/mention.ts** (130 lines)
+- Detects @mentions in group chats
+- Configurable bot names and aliases
+- Strips mention text from messages
+
+**src/group-policy.ts** (151 lines)
+- Group chat access control
+- Allowlist management for group conversations
+- Determines if bot should respond in group context
+
+**src/multi-account.ts** (312 lines)
+- Manages multiple WeCom applications simultaneously
+- Account-specific configuration and API clients
+- Routes messages to correct account
+
+**src/miniprogram.ts** (316 lines)
+- Mini program card integration
+- Template messages and notices
+- Mini program client wrapper
+
+**src/quote.ts** (168 lines)
+- Message quoting/reply functionality
+- Extracts quoted message context
+
+**src/runtime.ts** (21 lines)
+- Stores OpenClaw runtime context
+- Provides access to browser control and other runtime features
+
+**src/types.ts** (230 lines)
+- TypeScript type definitions for all WeCom message types
+- API request/response types
+- Configuration schemas
+
+## Message Flow
+
+### Incoming Messages (WeCom → OpenClaw)
+
+1. WeCom sends encrypted XML to webhook endpoint
+2. `monitor.ts` receives POST request at `/wecom/callback`
+3. Decrypt message body using AES-256-CBC
+4. Verify SHA1 signature
+5. Parse XML to extract message content
+6. Check for duplicates (message deduplication)
+7. Handle @mentions in group chats
+8. Dispatch to OpenClaw runtime for AI processing
+
+### Outgoing Messages (OpenClaw → WeCom)
+
+1. OpenClaw runtime calls channel's `send()` method
+2. `channel.ts` formats message for WeCom API
+3. `api.ts` sends HTTP request to WeCom API
+4. Handles media upload if needed (images, files, etc.)
+5. Returns success/failure status
+
+## Configuration
+
+The plugin requires these environment variables in `~/.openclaw/openclaw.json`:
+
+```json
+{
+  "env": {
+    "WECOM_CORP_ID": "ww1234567890abcdef",
+    "WECOM_CORP_SECRET": "your-app-secret",
+    "WECOM_AGENT_ID": "1000001",
+    "WECOM_CALLBACK_TOKEN": "your-token",
+    "WECOM_CALLBACK_AES_KEY": "your-43-character-aes-key"
+  },
+  "plugins": {
+    "entries": {
+      "wecom": { "enabled": true }
+    }
+  }
+}
+```
+
+**Optional Configuration:**
+- `WECOM_BOT_NAME` - Bot name for @mention detection
+- `WECOM_BOT_ALIASES` - Comma-separated aliases
+- `WECOM_WELCOME_MESSAGE` - Auto-reply for new subscribers
+- `WECOM_CALLBACK_PORT` - Webhook port (default: 18789)
+- `WECOM_CALLBACK_PATH` - Webhook path (default: /wecom/callback)
+
+## Remote Browser Control
+
+This plugin integrates with OpenClaw's browser control feature:
+
+1. User sends command via WeCom (e.g., "打开浏览器访问淘宝")
+2. Message flows to OpenClaw AI agent
+3. AI agent uses browser tools to control remote PC
+4. Screenshots/results sent back via WeCom
+
+**Requirements:**
+- `browser.enabled: true` in OpenClaw config
+- Node Host running on target PC: `openclaw node run --host SERVER_IP --port 18789`
+- Gateway configured with `gateway.nodes.browser.mode: "auto"`
+
+## Security Implementation
+
+**Message Encryption:**
+- AES-256-CBC with PKCS7 padding
+- 43-character base64-encoded AES key from WeCom
+- Random 16-byte IV prepended to ciphertext
+
+**Signature Verification:**
+- SHA1 HMAC with callback token
+- Validates: token + timestamp + nonce + encrypted_msg
+- Prevents replay attacks and tampering
+
+**Message Deduplication:**
+- Tracks message IDs to prevent duplicate processing
+- Important for webhook retries
+
+## Testing
+
+Test files use Vitest with mocking:
+
+- **test/api.test.ts** - API client, token management, HTTP requests
+- **test/channel.test.ts** - Channel plugin interface
+- **test/crypto.test.ts** - Encryption/decryption, signature verification
+- **test/monitor.test.ts** - Webhook handling, message parsing
+- **test/parser.test.ts** - XML parsing, message extraction
+
+**Running specific tests:**
+```bash
+pnpm test test/crypto.test.ts  # Test encryption only
+pnpm test -- --grep "signature"  # Test signature verification
+```
+
+## Common Development Patterns
+
+### Adding a New Message Type
+
+1. Add type definition to `src/types.ts`
+2. Add parsing logic to `src/parser.ts`
+3. Add sending method to `src/api.ts`
+4. Update channel capabilities in `src/channel.ts`
+5. Add tests
+
+### Adding a New Event Handler
+
+```typescript
+// In your code or index.ts
+import { onEvent } from "./src/events.js";
+
+onEvent("click", async (event, config) => {
+  // Handle menu click event
+  console.log(`Menu clicked: ${event.eventKey}`);
+});
+```
+
+### Multi-Account Support
+
+```typescript
+import { getAccountManager } from "./src/multi-account.js";
+
+const manager = getAccountManager();
+manager.addAccount("account1", config1);
+manager.addAccount("account2", config2);
+
+// Messages automatically routed to correct account
+```
+
+## Important Notes
+
+- **Module System**: Uses ES modules (`.js` extensions in imports even for `.ts` files)
+- **TypeScript Config**: `noImplicitAny: false` - some APIs have loose typing
+- **Workspace Dependency**: This plugin expects to be in an OpenClaw pnpm workspace
+- **Webhook Endpoint**: Must be publicly accessible for WeCom to send callbacks
+- **Token Refresh**: Access tokens expire after 7200 seconds, automatically refreshed by `api.ts`
+
+## Documentation
+
+- **docs/** - Docsify documentation site (bilingual)
+- **docs-site/** - Mintlify documentation site
+- **README.md** - User-facing documentation with quick start guide
+- **CHANGELOG.md** - Version history and release notes
+
+## Debugging
+
+**Enable verbose logging:**
+```bash
+DEBUG=wecom:* node dist/entry.js gateway
+```
+
+**Check webhook connectivity:**
+```bash
+curl -X POST http://localhost:18789/wecom/callback \
+  -H "Content-Type: text/xml" \
+  -d '<xml>...</xml>'
+```
+
+**Verify token refresh:**
+- Tokens cached in memory with expiration tracking
+- Check logs for "Token refreshed" messages
+- Token endpoint: `https://qyapi.weixin.qq.com/cgi-bin/gettoken`

--- a/index.ts
+++ b/index.ts
@@ -15,7 +15,7 @@
  *
  * @see https://github.com/liujinqi/wecom-openclaw-integration
  */
-import type { OpenClawPlugin } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
 
 import { wecomPlugin, wecomDock } from "./src/channel.js";
@@ -28,13 +28,19 @@ import { loadMiniProgramConfigFromEnv } from "./src/miniprogram.js";
 /**
  * 插件定义
  */
-const plugin: OpenClawPlugin = {
-  id: "wecom",
+const plugin: {
+  id: string;
+  name: string;
+  description: string;
+  configSchema: any;
+  register: (api: OpenClawPluginApi) => void;
+} = {
+  id: "wecom-openclaw-integration",
   name: "WeCom",
   description: "OpenClaw WeCom (企业微信) channel plugin",
   configSchema: emptyPluginConfigSchema(),
 
-  register(api) {
+  register(api: OpenClawPluginApi) {
     // 设置运行时
     setWeComRuntime(api.runtime);
 
@@ -79,8 +85,9 @@ export default plugin;
 export { WeComCrypto, generateNonce, getTimestamp } from "./src/crypto.js";
 export { WeComApiClient } from "./src/api.js";
 export { parseMessage, getMessageId, isEventMessage } from "./src/parser.js";
-export { handleWeComWebhookRequest, getWeComConfig, startMonitor, createMonitorServer } from "./src/monitor.js";
+export { handleWeComWebhookRequest, getWeComConfig, createMonitorServer } from "./src/monitor.js";
 export { wecomPlugin, wecomDock } from "./src/channel.js";
+export { wecomOutbound } from "./src/outbound.js";
 
 // 多账号支持
 export {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,10 +1,10 @@
 {
-  "id": "wecom",
+  "id": "wecom-openclaw-integration",
   "name": "WeCom Integration",
   "description": "Connect OpenClaw AI agent to WeCom (企业微信) - Send messages, control browsers, and automate tasks via WeCom",
   "version": "1.0.0",
   "channels": [
-    "wecom"
+    "wecom-openclaw-integration"
   ],
   "configSchema": {
     "type": "object",

--- a/package.json
+++ b/package.json
@@ -40,18 +40,19 @@
     "install": {
       "npmSpec": "wecom-openclaw-integration",
       "localPath": "extensions/wecom",
-      "defaultChoice": "local",
-      "pluginId": "wecom"
+      "defaultChoice": "npm",
+      "pluginId": "wecom-openclaw-integration"
     }
   },
   "dependencies": {
     "fast-xml-parser": "^4.3.0",
     "zod": "^3.22.0"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
-  },
   "peerDependencies": {
     "openclaw": ">=2026.1.26"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.0",
+    "typescript": "^5.9.3"
   }
 }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -6,9 +6,11 @@
 import {
   type ChannelDock,
   type ChannelPlugin,
+  DEFAULT_ACCOUNT_ID,
 } from "openclaw/plugin-sdk";
 import type { WeComAccountConfig, WeComResolvedAccount, WeComSendMessageResponse } from "./types.js";
 import { WeComApiClient } from "./api.js";
+import { wecomOutbound } from "./outbound.js";
 
 // ============================================
 // API 客户端缓存
@@ -65,120 +67,69 @@ export const wecomPlugin: ChannelPlugin<WeComResolvedAccount> = {
   },
 
   capabilities: {
-    supportsThreading: false,
-    supportsEditing: false,
-    supportsDeleting: false,
-    supportsReactions: false,
-    supportsReplies: false,
-    supportsForwarding: false,
-    supportsMedia: true,
-    supportsMarkdown: true,
-    maxMessageLength: 2048,
+    chatTypes: ["direct", "group"],
+    polls: false,
+    threads: false,
+    media: true,
+    reactions: false,
+    edit: false,
+    reply: false,
   },
 
   config: {
-    /**
-     * 列出所有账户 ID
-     */
-    listAccountIds(): string[] {
+    listAccountIds: () => [DEFAULT_ACCOUNT_ID],
+    resolveAccount: (cfg, accountId) => {
       const config = createAccountFromEnv();
-      if (!config) {
-        return [];
-      }
-      return [`wecom:${config.corpId}:${config.agentId}`];
-    },
 
-    /**
-     * 解析账户配置
-     */
-    resolveAccount(raw: unknown): WeComResolvedAccount | null {
-      const config = raw as WeComAccountConfig;
-
-      // 验证必需字段
+      // Always return an account object, but mark as not configured if missing credentials
       if (!config?.corpId || !config?.corpSecret || !config?.agentId) {
-        return null;
+        return {
+          accountId: accountId?.trim() || DEFAULT_ACCOUNT_ID,
+          enabled: false,
+          configured: false,
+          config: {} as WeComAccountConfig,
+          corpId: "",
+          agentId: 0,
+        };
       }
 
       if (!config?.callbackToken || !config?.callbackAesKey) {
-        return null;
+        return {
+          accountId: accountId?.trim() || DEFAULT_ACCOUNT_ID,
+          enabled: false,
+          configured: false,
+          config,
+          corpId: config.corpId,
+          agentId: config.agentId,
+        };
       }
 
       // 验证 AES Key 长度
       if (config.callbackAesKey.length !== 43) {
         console.warn("[WeCom] Invalid callbackAesKey length, expected 43 characters");
-        return null;
+        return {
+          accountId: accountId?.trim() || DEFAULT_ACCOUNT_ID,
+          enabled: false,
+          configured: false,
+          config,
+          corpId: config.corpId,
+          agentId: config.agentId,
+        };
       }
 
       return {
+        accountId: accountId?.trim() || DEFAULT_ACCOUNT_ID,
+        enabled: true,
+        configured: true,
         config,
         corpId: config.corpId,
         agentId: config.agentId,
       };
     },
-
-    /**
-     * 获取账户唯一标识
-     */
-    getAccountId(account: WeComResolvedAccount): string {
-      return `wecom:${account.corpId}:${account.agentId}`;
-    },
-
-    /**
-     * 获取账户显示标签
-     */
-    getAccountLabel(account: WeComResolvedAccount): string {
-      return `WeCom Agent ${account.agentId}`;
-    },
+    defaultAccountId: () => DEFAULT_ACCOUNT_ID,
   },
 
-  outbound: {
-    /**
-     * 发送消息
-     */
-    async send(ctx: {
-      account: WeComResolvedAccount;
-      target: string;
-      content: string;
-      options?: {
-        markdown?: boolean;
-      };
-    }): Promise<{
-      success: boolean;
-      messageId?: string;
-      error?: string;
-    }> {
-      const { account, target, content, options } = ctx;
-      const client = getApiClient(account);
-
-      try {
-        let response: WeComSendMessageResponse;
-
-        // 根据选项决定发送文本还是 Markdown
-        if (options?.markdown) {
-          response = await client.sendMarkdown(target, content);
-        } else {
-          response = await client.sendText(target, content);
-        }
-
-        if (response.errcode !== 0) {
-          return {
-            success: false,
-            error: `[${response.errcode}] ${response.errmsg}`,
-          };
-        }
-
-        return {
-          success: true,
-          messageId: response.msgid,
-        };
-      } catch (error) {
-        return {
-          success: false,
-          error: error instanceof Error ? error.message : String(error),
-        };
-      }
-    },
-  },
+  outbound: wecomOutbound,
 };
 
 // ============================================

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -626,9 +626,8 @@ async function readBody(req: IncomingMessage): Promise<string> {
 }
 
 async function loadConfigFromRuntime(core: any): Promise<OpenClawConfig> {
-  // Try to get config from runtime if available
-  // This is a fallback - ideally config should be passed in options
-  return {} as OpenClawConfig;
+  // Load config from runtime
+  return core.config.loadConfig();
 }
 
 function createRuntimeFromCore(core: any): RuntimeEnv {

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -2,25 +2,26 @@
  * WeCom Monitor - 消息处理管道
  *
  * 负责接收企业微信回调，解析消息，并路由到 OpenClaw AI Agent
+ *
+ * Refactored to use only public openclaw/plugin-sdk APIs
  */
 import type { IncomingMessage, ServerResponse } from "node:http";
 import http from "node:http";
+import type { OpenClawConfig, RuntimeEnv, HistoryEntry } from "openclaw/plugin-sdk";
+import {
+  buildPendingHistoryContextFromMap,
+  recordPendingHistoryEntryIfEnabled,
+  clearHistoryEntriesIfEnabled,
+  DEFAULT_GROUP_HISTORY_LIMIT,
+} from "openclaw/plugin-sdk";
 import type { WeComAccountConfig, WeComParsedMessage, WeComExtendedConfig } from "./types.js";
 import { WeComCrypto } from "./crypto.js";
 import { parseMessage, getMessageId, isEventMessage, isGroupMessage, getSessionId, getSenderId } from "./parser.js";
 import { WeComApiClient } from "./api.js";
 import { shouldRespond, processMessageContent, type MentionConfig } from "./mention.js";
 import { isGroupAllowed, isUserAllowedInGroup, groupRequiresMention, DEFAULT_GROUP_CONFIG } from "./group-policy.js";
-
-// OpenClaw imports
-import { dispatchReplyWithBufferedBlockDispatcher } from "../../../src/auto-reply/reply/provider-dispatcher.js";
-import { resolveEffectiveMessagesConfig } from "../../../src/agents/identity.js";
-import { chunkMarkdownText } from "../../../src/auto-reply/chunk.js";
-import { resolveAgentRoute } from "../../../src/routing/resolve-route.js";
-import { loadConfig } from "../../../src/config/config.js";
-import { loadWebMedia } from "../../../src/web/media.js";
-import { mediaKindFromMime } from "../../../src/media/constants.js";
-import type { MsgContext } from "../../../src/auto-reply/types.js";
+import { getWeComRuntime } from "./runtime.js";
+import { createWeComReplyDispatcher } from "./reply-dispatcher.js";
 
 // ============================================
 // 消息去重
@@ -263,6 +264,12 @@ export interface ProcessMessageOptions {
   extendedConfig?: WeComExtendedConfig;
   /** 是否处理事件消息 */
   handleEvents?: boolean;
+  /** OpenClaw 配置 */
+  cfg?: OpenClawConfig;
+  /** Runtime 环境 */
+  runtime?: RuntimeEnv;
+  /** 聊天历史记录 */
+  chatHistories?: Map<string, HistoryEntry[]>;
 }
 
 // 事件处理器 (延迟导入避免循环依赖)
@@ -298,8 +305,6 @@ export async function processInboundMessage(
   const senderId = getSenderId(msg);
   const sessionId = getSessionId(msg);
   const isGroup = isGroupMessage(msg);
-  const accountId = `wecom:${accountConfig.corpId}:${accountConfig.agentId}`;
-  const client = getApiClient(accountConfig);
   const extConfig = options.extendedConfig;
 
   // 群聊日志
@@ -337,7 +342,9 @@ export async function processInboundMessage(
 
   // 处理不同类型的消息
   let content = "";
-  const mediaFiles: string[] = [];
+  const mediaPayloads: Array<{ kind: string; url?: string; buffer?: Buffer; contentType?: string }> = [];
+
+  const client = getApiClient(accountConfig);
 
   switch (msg.msgType) {
     case "text":
@@ -350,8 +357,8 @@ export async function processInboundMessage(
         try {
           console.log(`[WeCom] Downloading image from user ${senderId}...`);
           const filePath = await client.downloadMedia(msg.mediaId);
-          mediaFiles.push(filePath);
-          content = `[用户发送了一张图片: ${filePath}]`;
+          content = `[用户发送了一张图片]`;
+          mediaPayloads.push({ kind: "image", url: filePath });
           console.log(`[WeCom] Image downloaded: ${filePath}`);
         } catch (err) {
           console.error(`[WeCom] Failed to download image:`, err);
@@ -365,8 +372,8 @@ export async function processInboundMessage(
         try {
           console.log(`[WeCom] Downloading voice from user ${senderId}...`);
           const filePath = await client.downloadMedia(msg.mediaId);
-          mediaFiles.push(filePath);
-          content = `[用户发送了一条语音消息: ${filePath}]`;
+          content = `[用户发送了一条语音消息]`;
+          mediaPayloads.push({ kind: "audio", url: filePath });
           console.log(`[WeCom] Voice downloaded: ${filePath}`);
         } catch (err) {
           console.error(`[WeCom] Failed to download voice:`, err);
@@ -380,8 +387,8 @@ export async function processInboundMessage(
         try {
           console.log(`[WeCom] Downloading video from user ${senderId}...`);
           const filePath = await client.downloadMedia(msg.mediaId);
-          mediaFiles.push(filePath);
-          content = `[用户发送了一个视频: ${filePath}]`;
+          content = `[用户发送了一个视频]`;
+          mediaPayloads.push({ kind: "video", url: filePath });
           console.log(`[WeCom] Video downloaded: ${filePath}`);
         } catch (err) {
           console.error(`[WeCom] Failed to download video:`, err);
@@ -397,8 +404,8 @@ export async function processInboundMessage(
           const fileSize = msg.fileSize ? `${Math.round(msg.fileSize / 1024)}KB` : "未知大小";
           console.log(`[WeCom] Downloading file from user ${senderId}: ${fileName} (${fileSize})...`);
           const filePath = await client.downloadMedia(msg.mediaId);
-          mediaFiles.push(filePath);
-          content = `[用户发送了文件: ${fileName} (${fileSize}), 路径: ${filePath}]`;
+          content = `[用户发送了文件: ${fileName} (${fileSize})]`;
+          mediaPayloads.push({ kind: "document", url: filePath });
           console.log(`[WeCom] File downloaded: ${filePath}`);
         } catch (err) {
           console.error(`[WeCom] Failed to download file:`, err);
@@ -418,12 +425,11 @@ export async function processInboundMessage(
     case "emotion":
       if (msg.mediaId) {
         try {
-          // emotionType: 1=gif表情, 2=png表情
           const emotionTypeName = msg.emotionType === 1 ? "GIF" : "PNG";
           console.log(`[WeCom] Downloading ${emotionTypeName} emotion from user ${senderId}...`);
           const filePath = await client.downloadMedia(msg.mediaId);
-          mediaFiles.push(filePath);
-          content = `[用户发送了${emotionTypeName}表情: ${filePath}]`;
+          content = `[用户发送了${emotionTypeName}表情]`;
+          mediaPayloads.push({ kind: "image", url: filePath });
           console.log(`[WeCom] Emotion downloaded: ${filePath}`);
         } catch (err) {
           console.error(`[WeCom] Failed to download emotion:`, err);
@@ -447,134 +453,146 @@ export async function processInboundMessage(
   console.log(`[WeCom] Processing ${msg.msgType} message from ${senderId}${isGroup ? ` in group ${msg.chatId}` : ""}: ${content.substring(0, 100)}`);
 
   try {
-    // 加载 OpenClaw 配置
-    const cfg = await loadConfig();
-
-    // 解析路由 - 群聊使用群 ID，单聊使用用户 ID
-    const chatType = isGroup ? "group" : "direct";
-    const route = resolveAgentRoute({
-      cfg,
-      channel: "wecom",
-      accountId,
-      chatId: sessionId,
-      chatType,
-    });
-
-    console.log(`[WeCom] Route resolved: agentId=${route.agentId}, chatType=${chatType}`);
-
-    // 构建发送者标签 (群聊显示用户 ID，单聊显示用户 ID)
-    const senderLabel = isGroup ? `${senderId}@${msg.chatId}` : senderId;
-
-    // 构建消息上下文
-    const ctx: MsgContext = {
-      Body: content,
-      BodyForAgent: content,
-      RawBody: content,
-      CommandBody: content,
-      BodyForCommands: content,
-      From: senderId,
-      To: accountId,
-      SessionKey: `wecom:${sessionId}`,
-      AccountId: accountId,
-      MessageSid: msg.msgId || `wecom-${Date.now()}`,
-      channel: "wecom",
-      accountId,
-      chatId: sessionId,
-      chatType,
-      senderId,
-      senderLabel,
-      messageId: msg.msgId || `wecom-${Date.now()}`,
-      timestamp: new Date(msg.createTime * 1000),
-      text: content,
-      raw: msg,
-      // 群聊相关字段
-      ...(isGroup && { groupId: msg.chatId }),
-      // 添加媒体文件路径供 agent 使用
-      ...(mediaFiles.length > 0 && { mediaFiles }),
-    };
+    const core = getWeComRuntime();
+    const cfg = options.cfg ?? await loadConfigFromRuntime(core);
+    const runtime = options.runtime ?? createRuntimeFromCore(core);
 
     // 确定回复目标 (群聊回复到群，单聊回复给用户)
     const replyTarget = isGroup ? msg.chatId! : senderId;
 
-    // 使用 OpenClaw 的消息分发系统
-    console.log(`[WeCom] Dispatching to AI agent...`);
+    // WeCom 标识符
+    const wecomFrom = `wecom:${senderId}`;
+    const wecomTo = isGroup ? `chat:${msg.chatId}` : `user:${senderId}`;
 
-    const { queuedFinal } = await dispatchReplyWithBufferedBlockDispatcher({
-      ctx,
+    // 解析路由
+    const route = core.channel.routing.resolveAgentRoute({
       cfg,
-      dispatcherOptions: {
-        responsePrefix: resolveEffectiveMessagesConfig(cfg, route.agentId).responsePrefix,
-        deliver: async (payload) => {
-          const client = getApiClient(accountConfig);
-
-          // 处理媒体文件
-          const mediaUrls = payload.mediaUrls || (payload.mediaUrl ? [payload.mediaUrl] : []);
-          if (mediaUrls.length > 0) {
-            console.log(`[WeCom] Delivering ${mediaUrls.length} media file(s) to ${replyTarget}...`);
-            for (const url of mediaUrls) {
-              try {
-                // 加载媒体并检测类型
-                const media = await loadWebMedia(url);
-                const kind = mediaKindFromMime(media.contentType ?? undefined);
-                console.log(`[WeCom] Sending ${kind}: ${url.substring(0, 80)}...`);
-
-                let response;
-                switch (kind) {
-                  case "image":
-                    response = await client.sendImageFromUrl(replyTarget, url);
-                    break;
-                  case "video":
-                    response = await client.sendVideoFromUrl(replyTarget, url);
-                    break;
-                  case "audio":
-                    // 企业微信语音需要 AMR 格式，暂时作为文件发送
-                    // TODO: 添加音频格式转换支持
-                    response = await client.sendFileFromUrl(replyTarget, url, media.fileName);
-                    break;
-                  case "document":
-                  default:
-                    response = await client.sendFileFromUrl(replyTarget, url, media.fileName);
-                    break;
-                }
-
-                if (response.errcode !== 0) {
-                  console.error(`[WeCom] ${kind} send failed: [${response.errcode}] ${response.errmsg}`);
-                } else {
-                  console.log(`[WeCom] ${kind} sent successfully`);
-                }
-              } catch (mediaErr) {
-                console.error(`[WeCom] Media send error:`, mediaErr);
-              }
-            }
-          }
-
-          // 处理文本
-          const text = payload.text || "";
-          if (text) {
-            console.log(`[WeCom] Delivering reply to ${replyTarget}: ${text.substring(0, 100)}...`);
-
-            // 分块发送长消息
-            const chunks = chunkMarkdownText(text, 2000);
-
-            for (const chunk of chunks) {
-              const response = await client.sendText(replyTarget, chunk);
-              if (response.errcode !== 0) {
-                throw new Error(`[${response.errcode}] ${response.errmsg}`);
-              }
-            }
-
-            console.log(`[WeCom] Reply delivered successfully`);
-          }
-        },
-        onError: (err, info) => {
-          console.error(`[WeCom] ${info.kind} reply failed:`, err);
-        },
+      channel: "wecom",
+      peer: {
+        kind: isGroup ? "group" : "dm",
+        id: isGroup ? msg.chatId! : senderId,
       },
-      replyOptions: {},
     });
 
+    console.log(`[WeCom] Route resolved: agentId=${route.agentId}, sessionKey=${route.sessionKey}`);
+
+    const preview = content.replace(/\s+/g, " ").slice(0, 160);
+    const inboundLabel = isGroup
+      ? `WeCom message in group ${msg.chatId}`
+      : `WeCom DM from ${senderId}`;
+
+    core.system.enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
+      sessionKey: route.sessionKey,
+      contextKey: `wecom:message:${sessionId}:${msg.msgId}`,
+    });
+
+    // 格式化消息体
+    const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(cfg);
+    const speaker = senderId;
+    let messageBody = `${speaker}: ${content}`;
+
+    const envelopeFrom = isGroup ? `${msg.chatId}:${senderId}` : senderId;
+
+    const body = core.channel.reply.formatAgentEnvelope({
+      channel: "WeCom",
+      from: envelopeFrom,
+      timestamp: new Date(msg.createTime * 1000),
+      envelope: envelopeOptions,
+      body: messageBody,
+    });
+
+    // 处理群聊历史记录
+    let combinedBody = body;
+    const historyKey = isGroup ? msg.chatId : undefined;
+    const chatHistories = options.chatHistories ?? new Map<string, HistoryEntry[]>();
+    const historyLimit = DEFAULT_GROUP_HISTORY_LIMIT;
+
+    if (isGroup && historyKey && chatHistories) {
+      combinedBody = buildPendingHistoryContextFromMap({
+        historyMap: chatHistories,
+        historyKey,
+        limit: historyLimit,
+        currentMessage: combinedBody,
+        formatEntry: (entry) =>
+          core.channel.reply.formatAgentEnvelope({
+            channel: "WeCom",
+            from: `${msg.chatId}:${entry.sender}`,
+            timestamp: entry.timestamp,
+            body: entry.body,
+            envelope: envelopeOptions,
+          }),
+      });
+    }
+
+    // 构建上下文
+    const ctxPayload = core.channel.reply.finalizeInboundContext({
+      Body: combinedBody,
+      RawBody: rawContent,
+      CommandBody: content,
+      From: wecomFrom,
+      To: wecomTo,
+      SessionKey: route.sessionKey,
+      AccountId: route.accountId,
+      ChatType: isGroup ? "group" : "direct",
+      GroupSubject: isGroup ? msg.chatId : undefined,
+      SenderName: senderId,
+      SenderId: senderId,
+      Provider: "wecom" as const,
+      Surface: "wecom" as const,
+      MessageSid: msg.msgId || `wecom-${Date.now()}`,
+      Timestamp: msg.createTime * 1000,
+      WasMentioned: isGroup && requireMention,
+      CommandAuthorized: true,
+      OriginatingChannel: "wecom" as const,
+      OriginatingTo: wecomTo,
+      Media: mediaPayloads.length > 0 ? mediaPayloads : undefined,
+    });
+
+    // 创建回复分发器
+    const { dispatcher, replyOptions, markDispatchIdle } = createWeComReplyDispatcher({
+      cfg,
+      agentId: route.agentId,
+      runtime,
+      accountConfig,
+      replyTarget,
+    });
+
+    console.log(`[WeCom] Dispatching to agent (session=${route.sessionKey})`);
+
+    // 分发到 AI 代理
+    const { queuedFinal, counts } = await core.channel.reply.dispatchReplyFromConfig({
+      ctx: ctxPayload,
+      cfg,
+      dispatcher,
+      replyOptions,
+    });
+
+    markDispatchIdle();
+
+    // 记录历史
+    if (isGroup && historyKey) {
+      recordPendingHistoryEntryIfEnabled({
+        historyMap: chatHistories,
+        historyKey,
+        limit: historyLimit,
+        entry: {
+          sender: senderId,
+          body: content,
+          timestamp: msg.createTime * 1000,
+        },
+      });
+
+      if (queuedFinal) {
+        clearHistoryEntriesIfEnabled({
+          historyMap: chatHistories,
+          historyKey,
+          limit: historyLimit,
+        });
+      }
+    }
+
     if (queuedFinal) {
-      console.log(`[WeCom] Response queued for ${replyTarget}`);
+      console.log(`[WeCom] Response queued for ${replyTarget}, counts:`, counts);
     } else {
       console.log(`[WeCom] No response generated for message from ${senderId}`);
     }
@@ -583,11 +601,41 @@ export async function processInboundMessage(
 
     // 发送错误提示
     const client = getApiClient(accountConfig);
+    const replyTarget = isGroup ? msg.chatId! : senderId;
     await client.sendText(
       replyTarget,
       `抱歉，处理消息时出错: ${err instanceof Error ? err.message : String(err)}`
     );
   }
+}
+
+// ============================================
+// 辅助函数
+// ============================================
+async function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    req.on("data", (chunk) => {
+      body += chunk.toString();
+    });
+    req.on("end", () => {
+      resolve(body);
+    });
+    req.on("error", reject);
+  });
+}
+
+async function loadConfigFromRuntime(core: any): Promise<OpenClawConfig> {
+  // Try to get config from runtime if available
+  // This is a fallback - ideally config should be passed in options
+  return {} as OpenClawConfig;
+}
+
+function createRuntimeFromCore(core: any): RuntimeEnv {
+  return {
+    log: console.log,
+    error: console.error,
+  } as RuntimeEnv;
 }
 
 // ============================================
@@ -660,78 +708,40 @@ export function createMonitorServer(config: MonitorConfig): http.Server {
           return;
         }
 
-        // 解密
+        // 解密消息
         const { message: xml } = config.crypto.decrypt(encrypted);
 
         // 解析消息
         const msg = parseMessage(xml);
 
-        // 去重
-        const msgId = getMessageId(msg);
-        if (!isDuplicate(msgId)) {
-          // 异步处理消息，不阻塞响应
-          Promise.resolve(config.onMessage(msg, xml)).catch((err) => {
-            config.onError?.(err);
-          });
-        }
-
         // 必须在 5 秒内响应
         res.writeHead(200, { "Content-Type": "text/plain" });
         res.end("success");
+
+        // 异步处理消息
+        Promise.resolve(config.onMessage(msg, xml)).catch((err) => {
+          if (config.onError) {
+            config.onError(err);
+          } else {
+            console.error("[WeCom] Message handler error:", err);
+          }
+        });
         return;
       }
 
       res.writeHead(405);
       res.end("Method Not Allowed");
-    } catch (error) {
-      config.onError?.(error as Error);
-      res.writeHead(500);
-      res.end("Internal Server Error");
+    } catch (err) {
+      console.error("[WeCom] Server error:", err);
+      if (!res.headersSent) {
+        res.writeHead(500);
+        res.end("Internal Server Error");
+      }
+      if (config.onError) {
+        config.onError(err as Error);
+      }
     }
   });
 
   return server;
-}
-
-export async function startMonitor(
-  accountConfig: WeComAccountConfig,
-  onMessage: (msg: WeComParsedMessage, rawXml: string) => void | Promise<void>,
-  onError?: (error: Error) => void
-): Promise<http.Server> {
-  const crypto = new WeComCrypto({
-    token: accountConfig.callbackToken,
-    aesKey: accountConfig.callbackAesKey,
-    corpId: accountConfig.corpId,
-  });
-
-  const port = accountConfig.callbackPort || 8080;
-  const path = accountConfig.callbackPath || "/wecom/callback";
-
-  const server = createMonitorServer({
-    port,
-    path,
-    crypto,
-    onMessage,
-    onError,
-  });
-
-  return new Promise((resolve, reject) => {
-    server.on("error", reject);
-    server.listen(port, "0.0.0.0", () => {
-      console.log(`[WeCom] Callback server started on port ${port}`);
-      resolve(server);
-    });
-  });
-}
-
-// ============================================
-// 工具函数
-// ============================================
-function readBody(req: IncomingMessage): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    req.on("data", (chunk: Buffer) => chunks.push(chunk));
-    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
-    req.on("error", reject);
-  });
 }

--- a/src/outbound.ts
+++ b/src/outbound.ts
@@ -1,0 +1,86 @@
+/**
+ * WeCom Outbound Adapter
+ *
+ * Handles sending messages through WeCom API
+ */
+import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk";
+import { getWeComRuntime } from "./runtime.js";
+import { WeComApiClient } from "./api.js";
+import { getWeComConfig } from "./monitor.js";
+
+export const wecomOutbound: ChannelOutboundAdapter = {
+  deliveryMode: "direct",
+  chunker: (text, limit) => getWeComRuntime().channel.text.chunkMarkdownText(text, limit),
+  chunkerMode: "markdown",
+  textChunkLimit: 2000,
+  sendText: async ({ cfg, to, text }) => {
+    const config = getWeComConfig();
+    if (!config) {
+      throw new Error("WeCom not configured");
+    }
+
+    const client = new WeComApiClient({
+      corpId: config.corpId,
+      corpSecret: config.corpSecret,
+      agentId: config.agentId,
+    });
+
+    const result = await client.sendText(to, text);
+    return {
+      channel: "wecom",
+      success: result.errcode === 0,
+      messageId: result.msgid || "",
+      error: result.errcode !== 0 ? `[${result.errcode}] ${result.errmsg}` : undefined,
+    };
+  },
+  sendMedia: async ({ cfg, to, text, mediaUrl }) => {
+    const config = getWeComConfig();
+    if (!config) {
+      throw new Error("WeCom not configured");
+    }
+
+    const client = new WeComApiClient({
+      corpId: config.corpId,
+      corpSecret: config.corpSecret,
+      agentId: config.agentId,
+    });
+
+    // Send text first if provided
+    if (text?.trim()) {
+      await client.sendText(to, text);
+    }
+
+    // Upload and send media if URL provided
+    if (mediaUrl) {
+      try {
+        const result = await client.sendImageFromUrl(to, mediaUrl);
+        return {
+          channel: "wecom",
+          success: result.errcode === 0,
+          messageId: result.msgid || "",
+          error: result.errcode !== 0 ? `[${result.errcode}] ${result.errmsg}` : undefined,
+        };
+      } catch (err) {
+        console.error(`[WeCom] sendMedia failed:`, err);
+        // Fallback to URL link if upload fails
+        const fallbackText = `📎 ${mediaUrl}`;
+        const result = await client.sendText(to, fallbackText);
+        return {
+          channel: "wecom",
+          success: result.errcode === 0,
+          messageId: result.msgid || "",
+          error: result.errcode !== 0 ? `[${result.errcode}] ${result.errmsg}` : undefined,
+        };
+      }
+    }
+
+    // No media URL, just return text result
+    const result = await client.sendText(to, text ?? "");
+    return {
+      channel: "wecom",
+      success: result.errcode === 0,
+      messageId: result.msgid || "",
+      error: result.errcode !== 0 ? `[${result.errcode}] ${result.errmsg}` : undefined,
+    };
+  },
+};

--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -1,0 +1,126 @@
+/**
+ * WeCom Reply Dispatcher
+ *
+ * Creates a dispatcher for sending replies back to WeCom
+ */
+import {
+  createReplyPrefixContext,
+  createTypingCallbacks,
+  logTypingFailure,
+  type OpenClawConfig,
+  type RuntimeEnv,
+  type ReplyPayload,
+} from "openclaw/plugin-sdk";
+import { getWeComRuntime } from "./runtime.js";
+import { WeComApiClient } from "./api.js";
+import type { WeComAccountConfig } from "./types.js";
+
+export type CreateWeComReplyDispatcherParams = {
+  cfg: OpenClawConfig;
+  agentId: string;
+  runtime: RuntimeEnv;
+  accountConfig: WeComAccountConfig;
+  replyTarget: string;
+};
+
+export type WeComReplyDispatcherResult = {
+  dispatcher: {
+    sendToolResult: (payload: ReplyPayload) => boolean;
+    sendBlockReply: (payload: ReplyPayload) => boolean;
+    sendFinalReply: (payload: ReplyPayload) => boolean;
+    waitForIdle: () => Promise<void>;
+    getQueuedCounts: () => Record<string, number>;
+  };
+  replyOptions: Record<string, any>;
+  markDispatchIdle: () => void;
+};
+
+export function createWeComReplyDispatcher(params: CreateWeComReplyDispatcherParams): WeComReplyDispatcherResult {
+  const core = getWeComRuntime();
+  const { cfg, agentId, accountConfig, replyTarget } = params;
+
+  const prefixContext = createReplyPrefixContext({
+    cfg,
+    agentId,
+  });
+
+  // WeCom doesn't have a native typing indicator
+  const typingCallbacks = createTypingCallbacks({
+    start: async () => {
+      // No typing indicator for WeCom
+    },
+    stop: async () => {
+      // No typing indicator for WeCom
+    },
+    onStartError: (err) => {
+      logTypingFailure({
+        log: (message) => params.runtime.log?.(message),
+        channel: "wecom",
+        action: "start",
+        error: err,
+      });
+    },
+    onStopError: (err) => {
+      logTypingFailure({
+        log: (message) => params.runtime.log?.(message),
+        channel: "wecom",
+        action: "stop",
+        error: err,
+      });
+    },
+  });
+
+  // Use fixed values for text processing
+  const textChunkLimit = 2000;
+  const chunkMode: "length" | "newline" = "length";
+  const tableMode: "off" | "bullets" | "code" = "bullets";
+
+  const client = new WeComApiClient({
+    corpId: accountConfig.corpId,
+    corpSecret: accountConfig.corpSecret,
+    agentId: accountConfig.agentId,
+  });
+
+  const { dispatcher, replyOptions, markDispatchIdle } =
+    core.channel.reply.createReplyDispatcherWithTyping({
+      responsePrefix: prefixContext.responsePrefix,
+      responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
+      humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, agentId),
+      onReplyStart: typingCallbacks.onReplyStart,
+      deliver: async (payload: ReplyPayload) => {
+        params.runtime.log?.(`[WeCom] deliver called: text=${payload.text?.slice(0, 100)}`);
+        const text = payload.text ?? "";
+        if (!text.trim()) {
+          params.runtime.log?.(`[WeCom] deliver: empty text, skipping`);
+          return;
+        }
+
+        // Send text in chunks
+        const converted = core.channel.text.convertMarkdownTables(text, tableMode);
+        const chunks = core.channel.text.chunkTextWithMode(converted, textChunkLimit, chunkMode);
+        params.runtime.log?.(`[WeCom] deliver: sending ${chunks.length} text chunks to ${replyTarget}`);
+
+        for (const chunk of chunks) {
+          try {
+            await client.sendText(replyTarget, chunk);
+          } catch (err) {
+            params.runtime.error?.(`[WeCom] Failed to send text chunk: ${String(err)}`);
+          }
+        }
+      },
+      onError: (err, info) => {
+        params.runtime.error?.(`[WeCom] ${info.kind} reply failed: ${String(err)}`);
+        typingCallbacks.onIdle?.();
+      },
+      onIdle: typingCallbacks.onIdle,
+    });
+
+  return {
+    dispatcher,
+    replyOptions: {
+      ...replyOptions,
+      onModelSelected: prefixContext.onModelSelected,
+    },
+    markDispatchIdle,
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,9 @@ export interface WeComAccountConfig {
 }
 
 export interface WeComResolvedAccount {
+  accountId: string;
+  enabled: boolean;
+  configured: boolean;
   config: WeComAccountConfig;
   corpId: string;
   agentId: number;


### PR DESCRIPTION
This refactoring enables the plugin to be installed as a standalone npm package instead of requiring local installation in the OpenClaw workspace.

Changes:
- Created src/outbound.ts implementing ChannelOutboundAdapter
- Created src/reply-dispatcher.ts following Feishu plugin pattern
- Refactored src/monitor.ts to use PluginRuntime public APIs:
  - core.channel.routing.resolveAgentRoute()
  - core.channel.reply.dispatchReplyFromConfig()
  - core.channel.reply.formatAgentEnvelope()
  - core.channel.reply.finalizeInboundContext()
  - core.system.enqueueSystemEvent()
- Updated src/channel.ts with proper ChannelPlugin structure
- Updated index.ts to use OpenClawPluginApi type
- Updated types.ts with new WeComResolvedAccount interface
- Added .npmignore to exclude docs from npm package
- Updated CLAUDE.md with new installation instructions

Breaking change: Plugin ID changed from "wecom" to "wecom-openclaw-integration" to match npm package name.

## Summary by Sourcery

Refactor the WeCom OpenClaw channel plugin to rely on the public plugin SDK, enabling distribution as a standalone npm package and aligning its identity and configuration with the npm package name.

New Features:
- Introduce a dedicated outbound adapter for WeCom using the public ChannelOutboundAdapter interface.
- Add a reply dispatcher module that integrates with the public PluginRuntime reply APIs for WeCom responses.

Enhancements:
- Refactor inbound message handling to use public routing, reply, formatting, and system event APIs from the OpenClaw plugin SDK, including basic group history support and media metadata propagation.
- Update the channel plugin configuration model to use a default account ID, richer account state (enabled/configured flags), and simplified capabilities aligned with the standard ChannelPlugin shape.
- Adjust the plugin entrypoint to use the OpenClawPluginApi type and a more generic plugin descriptor shape, and stop exporting the legacy monitor start helper.
- Improve monitor server robustness by simplifying duplicate handling, ensuring non-blocking message processing, and hardening error handling and logging in the HTTP callback server.
- Extend WeCom account resolution types with a new WeComResolvedAccount shape that carries account identity and state flags.

Build:
- Add an .npmignore to exclude documentation from the published npm package.
- Switch OpenClaw to a peer dependency, add TypeScript and @types/node as dev dependencies, and update the plugin install metadata for npm-based installation.

Documentation:
- Add a comprehensive CLAUDE.md documenting plugin architecture, installation, configuration, and development workflow, including the move to the public plugin SDK.

Chores:
- Change the plugin ID to "wecom-openclaw-integration" to match the npm package name and update plugin install metadata accordingly.