### PR TITLE
Fix loadConfigFromRuntime to use PluginRuntime API

### DIFF
--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -626,12 +626,21 @@ async function readBody(req: IncomingMessage): Promise<string> {
 }
 
 async function loadConfigFromRuntime(core: any): Promise<OpenClawConfig> {
-  // 尝试从 runtime 获取配置
+  // Try legacy API: core.config.get() (older versions)
   if (core?.config?.get) {
     try {
       return await core.config.get();
     } catch (err) {
-      console.warn("[WeCom] Failed to load config from runtime:", err);
+      console.warn("[WeCom] Failed to load config from runtime via config.get():", err);
+    }
+  }
+
+  // Try current PluginRuntime API: core.config.loadConfig() (sync)
+  if (core?.config?.loadConfig) {
+    try {
+      return core.config.loadConfig();
+    } catch (err) {
+      console.warn("[WeCom] Failed to load config from runtime via config.loadConfig():", err);
     }
   }
 


### PR DESCRIPTION
The PluginRuntime type in OpenClaw's plugin SDK (src/plugins/runtime/types.ts:180-183) exposes config via config.loadConfig(), not config.get(). All official extensions (Matrix, Mattermost, Nextcloud-Talk, etc.) use core.config.loadConfig() to retrieve configuration - for example, Matrix at extensions/matrix/src/matrix/monitor/index.ts:36 uses let cfg = core.config.loadConfig(). The WeCom plugin was checking for a non-existent config.get() method, causing it to fall back to a hardcoded default config instead of loading the user's actual configuration.

## Summary by Sourcery

Ensure the WeCom monitor loads configuration from the PluginRuntime API while maintaining compatibility with older runtimes.

Bug Fixes:
- Fix runtime configuration loading so the WeCom plugin uses the actual user configuration instead of falling back to hardcoded defaults.

Enhancements:
- Add backward-compatible support for both legacy config.get() and current config.loadConfig() when reading configuration from the runtime, with clearer warning messages on failure.